### PR TITLE
Fix CI issues by switching to setup-miniconda action

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -10,25 +10,27 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+    - uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.8
-    - name: Add conda to system path
+        mamba-version: "*"
+        channel-priority: true
+        activate-environment: ai2es 
+        environment-file: environment.yml
+    - shell: bash -l {0}
       run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install dependencies
-      run: |
-        conda env update --file environment.yml --name base
+        conda info
+        conda list
+        conda config --show-sources
+        conda config --show
+        printenv | sort
     - name: Lint with flake8
       run: |
-        conda install flake8
+        mamba install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        conda install pytest
+        mamba install pytest
         pytest

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -14,7 +14,6 @@ jobs:
       with:
         mamba-version: "*"
         channel-priority: true
-        activate-environment: ai2es 
         environment-file: environment.yml
     - shell: bash -l {0}
       run: |

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -25,6 +25,7 @@ jobs:
         conda config --show
         printenv | sort
     - name: Lint with flake8
+      shell: bash -l {0}
       run: |
         mamba install flake8
         # stop the build if there are Python syntax errors or undefined names
@@ -32,6 +33,7 @@ jobs:
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
+      shell: bash -l {0}
       run: |
         mamba install pytest
         pytest

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -15,8 +15,11 @@ jobs:
         mamba-version: "*"
         channel-priority: true
         environment-file: environment.yml
+        auto-activate-base: false
+        activate-environment: ai2es
     - shell: bash -l {0}
       run: |
+        conda activate ai2es
         conda info
         conda list
         conda config --show-sources
@@ -24,6 +27,7 @@ jobs:
         printenv | sort
     - name: Lint with flake8
       run: |
+        conda activate ai2es
         mamba install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -31,5 +35,6 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
+        conda activate ai2es
         mamba install pytest
         pytest

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -16,10 +16,9 @@ jobs:
         channel-priority: true
         environment-file: environment.yml
         auto-activate-base: false
-        activate-environment: ai2es
+        activate-environment: test
     - shell: bash -l {0}
       run: |
-        conda activate ai2es
         conda info
         conda list
         conda config --show-sources
@@ -27,7 +26,6 @@ jobs:
         printenv | sort
     - name: Lint with flake8
       run: |
-        conda activate ai2es
         mamba install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
@@ -35,6 +33,5 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        conda activate ai2es
         mamba install pytest
         pytest


### PR DESCRIPTION
The CI template keeps hanging across multiple projects, so I updated it to use the setup-miniconda action instead of setup-python. After tweaking the arguments to get everything right, it now runs correctly here. I recommend anyone using the ai2es-template to pull the updated CI file when they get a chance.